### PR TITLE
Update API to fix behavior in iOS 13

### DIFF
--- a/THLabel/THLabel.m
+++ b/THLabel/THLabel.m
@@ -426,7 +426,7 @@
 
 - (CTFrameRef)frameRefFromSize:(CGSize)size textRectOutput:(CGRect *)textRectOutput CF_RETURNS_RETAINED {
 	// Set up font.
-    CTFontRef fontRef = CTFontCreateWithFontDescriptor((__bridge CTFontDescriptorRef)self.font.fontDescriptor, self.font.pointSize, NULL);
+	CTFontRef fontRef = CTFontCreateWithFontDescriptor((__bridge CTFontDescriptorRef)self.font.fontDescriptor, self.font.pointSize, NULL);
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_6_0
 	CTTextAlignment alignment = NSTextAlignmentToCTTextAlignment(self.textAlignment);
 #else

--- a/THLabel/THLabel.m
+++ b/THLabel/THLabel.m
@@ -426,7 +426,7 @@
 
 - (CTFrameRef)frameRefFromSize:(CGSize)size textRectOutput:(CGRect *)textRectOutput CF_RETURNS_RETAINED {
 	// Set up font.
-	CTFontRef fontRef = CTFontCreateWithName((__bridge CFStringRef)self.font.fontName, self.font.pointSize, NULL);
+    CTFontRef fontRef = CTFontCreateWithFontDescriptor((__bridge CTFontDescriptorRef)self.font.fontDescriptor, self.font.pointSize, NULL);
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_6_0
 	CTTextAlignment alignment = NSTextAlignmentToCTTextAlignment(self.textAlignment);
 #else


### PR DESCRIPTION
iOS 13 has changed APIs around fonts, so `CTFontCreateWithName` does not any longer work properly (at least with system fonts). It results with warnings like this:
```
CoreText performance note: Client called CTFontCreateWithName() using name ".SFUI-Ultralight" and got font with PostScript name "TimesNewRomanPSMT". For best performance, only use PostScript names when calling this API.
```
and incorrect fonts to be shown.

Instead `CTFontCreateWithFontDescriptor` should be used.