### PR TITLE
Fix layout for RTL mode

### DIFF
--- a/THLabel/THLabel.m
+++ b/THLabel/THLabel.m
@@ -522,6 +522,14 @@
 		case NSTextAlignmentRight:
 			textRect.origin.x = floorf(CGRectGetMinX(contentRect) + CGRectGetWidth(contentRect) - CGRectGetWidth(textRect));
 			break;
+            
+        case NSTextAlignmentNatural:
+            if ([UIView userInterfaceLayoutDirectionForSemanticContentAttribute:self.semanticContentAttribute] == UIUserInterfaceLayoutDirectionRightToLeft) {
+                textRect.origin.x = floorf(CGRectGetMinX(contentRect) + CGRectGetWidth(contentRect) - CGRectGetWidth(textRect));
+            } else {
+                textRect.origin.x = floorf(CGRectGetMinX(contentRect));
+            }
+            break;
 			
 		default:
 			textRect.origin.x = floorf(CGRectGetMinX(contentRect));

--- a/THLabel/THLabel.m
+++ b/THLabel/THLabel.m
@@ -522,14 +522,14 @@
 		case NSTextAlignmentRight:
 			textRect.origin.x = floorf(CGRectGetMinX(contentRect) + CGRectGetWidth(contentRect) - CGRectGetWidth(textRect));
 			break;
-            
-        case NSTextAlignmentNatural:
-            if ([UIView userInterfaceLayoutDirectionForSemanticContentAttribute:self.semanticContentAttribute] == UIUserInterfaceLayoutDirectionRightToLeft) {
-                textRect.origin.x = floorf(CGRectGetMinX(contentRect) + CGRectGetWidth(contentRect) - CGRectGetWidth(textRect));
-            } else {
-                textRect.origin.x = floorf(CGRectGetMinX(contentRect));
-            }
-            break;
+			
+		case NSTextAlignmentNatural:
+			if ([UIView userInterfaceLayoutDirectionForSemanticContentAttribute:self.semanticContentAttribute] == UIUserInterfaceLayoutDirectionRightToLeft) {
+				textRect.origin.x = floorf(CGRectGetMinX(contentRect) + CGRectGetWidth(contentRect) - CGRectGetWidth(textRect));
+			} else {
+				textRect.origin.x = floorf(CGRectGetMinX(contentRect));
+			}
+			break;
 			
 		default:
 			textRect.origin.x = floorf(CGRectGetMinX(contentRect));


### PR DESCRIPTION
Hi @tobihagemann!

First of all big thanks for your work!

I'd like to contribute a fix related to layout problems for RTL languages. If your label has `textAlignment` equals to `NSTextAlignmentNatural` (which is by default starting from iOS 9) and the system language is RTL, you'll end up with the wrong layout because behavior must be identical to `NSTextAlignmentRight` for this case.